### PR TITLE
Issue/add chart forecast horizons x axis

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -326,7 +326,7 @@ def metric_page():
                 yaxis=dict(tickmode='linear', tick0=0, dtick=60),
             )
 
-        st.plotly_chart(fig32, theme="streamlit")
+        st.plotly_chart(fig4, theme="streamlit")
 
     # add chart with forecast horizons on x-axis and line for each day in the date range
 
@@ -369,7 +369,7 @@ def metric_page():
             
         fig5.add_traces(traces)
 
-        st.plotly_chart(fig4, theme="streamlit")
+        st.plotly_chart(fig5, theme="streamlit")
     
 
     # comparing MAE and RMSE
@@ -401,7 +401,7 @@ def metric_page():
         ]
     )
 
-    st.plotly_chart(fig5, theme="streamlit")
+    st.plotly_chart(fig6, theme="streamlit")
 
     st.subheader("Raw Data")
     col1, col2 = st.columns([1, 1])

--- a/src/main.py
+++ b/src/main.py
@@ -279,7 +279,7 @@ def metric_page():
 
         st.plotly_chart(fig3, theme="streamlit")
 
-    fig32 = go.Figure(
+    fig4 = go.Figure(
         layout=go.Layout(
             title=go.layout.Title(text="Nowcasting MAE by Forecast Horizon for Date Range"),
             xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="MAE (MW)")),
@@ -310,7 +310,7 @@ def metric_page():
                     }
                 )
            
-                fig32.add_traces(
+                fig4.add_traces(
                     [
                         go.Scatter(
                             x=df_mae_horizon["MAE"],
@@ -321,7 +321,7 @@ def metric_page():
                             ),
                     ]
                 )
-                fig32.update_layout(
+                fig4.update_layout(
                 xaxis=dict(tickmode='linear', tick0=0, dtick=50),
                 yaxis=dict(tickmode='linear', tick0=0, dtick=60),
             )
@@ -330,7 +330,7 @@ def metric_page():
 
     # add chart with forecast horizons on x-axis and line for each day in the date range
 
-    fig4 = go.Figure(
+    fig5 = go.Figure(
          layout=go.Layout(
             title=go.layout.Title(text="Nowcasting MAE Forecast Horizon Values by Date"),
             xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="Forecast Horizon (minutes)")),
@@ -367,13 +367,13 @@ def metric_page():
                     )
                     )  
             
-        fig4.add_traces(traces)
+        fig5.add_traces(traces)
 
         st.plotly_chart(fig4, theme="streamlit")
     
 
     # comparing MAE and RMSE
-    fig5 = go.Figure(
+    fig6 = go.Figure(
         layout=go.Layout(
             title=go.layout.Title(text="Nowcasting MAE with RMSE for Comparison"),
             xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="Date")),
@@ -382,7 +382,7 @@ def metric_page():
         )
     )
 
-    fig5.add_traces(
+    fig6.add_traces(
         [
             go.Scatter(
                 x=df_mae["datetime_utc"],


### PR DESCRIPTION
# Pull Request

## Description

This PR updates the color scheme for the figures. 

<img width="872" alt="Screenshot 2023-05-22 at 15 45 36" src="https://github.com/openclimatefix/internal_ui/assets/86949265/e80d87f8-2f2a-43e7-bf7c-5587886f0d83">

It adds two scatter plots to show a general distribution of the MAE by forecast horizon: 

<img width="883" alt="Screenshot 2023-05-22 at 15 46 53" src="https://github.com/openclimatefix/internal_ui/assets/86949265/c5bfd745-3c97-4e49-92a4-265a36643540">

<img width="978" alt="Screenshot 2023-05-22 at 15 47 09" src="https://github.com/openclimatefix/internal_ui/assets/86949265/3c9bd9de-c1b2-400e-a362-0afc62a1f2de">


What I struggled with: 
In `fig5`, line 333 in `main.py`, the chart is supposed to display forecast horizon against MAE with a line displaying for each day. I struggled to capture a dataframe that could plot one line for each day showing the MAE (y-axis) at each forecast horizon (x-axis). The code currently breaks. 

## How Has This Been Tested?

Ran the code locally

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
