### PR TITLE
- filter by model

### DIFF
--- a/src/get_data.py
+++ b/src/get_data.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 from sqlalchemy.orm.session import Session
 
 from nowcasting_datamodel.models.gsp import LocationSQL
+from nowcasting_datamodel.models import MLModelSQL
 from nowcasting_datamodel.models.metric import DatetimeIntervalSQL, MetricSQL, MetricValueSQL
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ def get_metric_value(
     end_datetime_utc: Optional[datetime] = None,
     gsp_id: Optional[int] = None,
     forecast_horizon_minutes: Optional[int] = None,
+    model_name: Optional[str] = None,
 ) -> List[MetricValueSQL]:
     """
     Get Metric values, for example MAE for gsp_id 5 on 2023-01-01
@@ -64,6 +66,10 @@ def get_metric_value(
         # select forecast_horizon_minutes is Null, which gets the last forecast.
         # !! This has to be a double equals or it won't work
         query = query.filter(MetricValueSQL.forecast_horizon_minutes == None)
+
+    if model_name is not None:
+        query = query.join(MLModelSQL)
+        query = query.filter(MLModelSQL.name == model_name)
 
     # order by 'created_utc' desc, so we get the latest one
     query = query.order_by(


### PR DESCRIPTION
- only get forecast data once

# Pull Request

## Description

- only get forecast horizon data once
- add filter by `model_name`

## How Has This Been Tested?

Ran locally

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
